### PR TITLE
Añadí una función que obtiene la dirección IPv4 del servidor automáticamente

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,7 @@
 # PyDrop
-An Airdrop alternative for cross-platform **desktop** users. Made with Python.  
-***v1.01***  
-# Instrucciones en Español
-1. Si quieres instalar el código y correrlo desde tu consola sin usar el archivo .exe, deberás instalar los siguientes modulos usando "pip install...", (tqdm, socket)
-2. versión de python 3.x. TEN CUIDADO CON LAS VERSIONES DE 3.10+ puede que no estén habilitadas para los módulos usados.
-Por último el archivo se guardará en la dirección en donde se encuentra la APP, si está en el escritorio, se va a guardar ahí.
-
-Si tienes problemas con el código o no entiendes algo contáctame a bernardoolisan@gmail.com
-# English Instructions
+A cross-platform Airdrop alternative for **desktop** users made with Python.  
+***v1.02***  
+# Instructions
 1. If you want to install the code and run it from your console without using the .exe file, you must install the following modules using "pip install ...", (tqdm, socket)
 2. python version 3.x. BE CAREFUL WITH VERSIONS OF 3.10+ they may not be enabled for the modules used.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # PyDrop
-An Airdrop alternative for cross-platform users only for desktop with Python, -version 1.0
-with less effort, just as a practice.
-
-
-# Instrucciones Español
+An Airdrop alternative for cross-platform **desktop** users. Made with Python.  
+***v1.01***  
+# Instrucciones en Español
 1. Si quieres instalar el código y correrlo desde tu consola sin usar el archivo .exe, deberás instalar los siguientes modulos usando "pip install...", (tqdm, socket)
 2. versión de python 3.x. TEN CUIDADO CON LAS VERSIONES DE 3.10+ puede que no estén habilitadas para los módulos usados.
 Por último el archivo se guardará en la dirección en donde se encuentra la APP, si está en el escritorio, se va a guardar ahí.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 A cross-platform Airdrop alternative for **desktop** users made with Python.  
 ***v1.02***  
 # Instructions
-1. If you want to install the code and run it from your console without using the .exe file, you must install the following modules using "pip install ...", (tqdm, socket)
-2. python version 3.x. BE CAREFUL WITH VERSIONS OF 3.10+ they may not be enabled for the modules used.
+1. Install the modules
+```bash
+pip install tqdm socket
+```
+2. Make sure to use python 3
 
-Finally the file will be saved in the address where the APP is located, if it is on the desktop, it will be saved there.
-
+Finally. the file will be saved in the address where the app is located.
 If you have problems with the code or do not understand something, contact me at bernardoolisan@gmail.com
 

--- a/README.md
+++ b/README.md
@@ -2,34 +2,18 @@
 An Airdrop alternative for cross-platform users only for desktop with Python, -version 1.0
 with less effort, just as a practice.
 
-#################################################################################################################################################################################
 
 # Instrucciones Español
 1. Si quieres instalar el código y correrlo desde tu consola sin usar el archivo .exe, deberás instalar los siguientes modulos usando "pip install...", (tqdm, socket)
 2. versión de python 3.x. TEN CUIDADO CON LAS VERSIONES DE 3.10+ puede que no estén habilitadas para los módulos usados.
-
-# CÓMO OBTENER TU IP
-En la consola "cmd", escribe "ipconfig", deberás encontrar el IPV4 en el caso mío es 192.168.1.93 pero el tuyo será diferente.
-Deberás colocar en la <linea 9> del archivo "client.py" el host que es tu IPV4: "host = '192.168.1.93'", CÁMBIALO CON TU IPV4. 
-¡DEBE DE SER EL IPV4 DE EL DISPOSITIVO QUE ESTÁ COMO SERVIDOR!
-
 Por último el archivo se guardará en la dirección en donde se encuentra la APP, si está en el escritorio, se va a guardar ahí.
 
 Si tienes problemas con el código o no entiendes algo contáctame a bernardoolisan@gmail.com
-
-##################################################################################################################################################################################
-
 # English Instructions
 1. If you want to install the code and run it from your console without using the .exe file, you must install the following modules using "pip install ...", (tqdm, socket)
 2. python version 3.x. BE CAREFUL WITH VERSIONS OF 3.10+ they may not be enabled for the modules used.
-
-# HOW TO GET YOUR IP
-In the console "cmd", write "ipconfig", you should find the IPV4 in my case it is 192.168.1.93 but yours will be different.
-You must put in the <line 9> of the file "client.py" the host that is your IPV4: "host = '192.168.1.93'", CHANGE IT WITH YOUR IPV4.
-¡IT MUST BE THE IPV4 OF THE DEVICE THAT IS AS A SERVER!
 
 Finally the file will be saved in the address where the APP is located, if it is on the desktop, it will be saved there.
 
 If you have problems with the code or do not understand something, contact me at bernardoolisan@gmail.com
 
-##################################################################################################################################################################################

--- a/client.py
+++ b/client.py
@@ -1,12 +1,20 @@
 import socket
 import tqdm
 import os
+import subprocess 
+import re 
 
 SEPARATOR = '<SEPARATOR>'
 BUFFER_SIZE = 4096
 
+# this function will return ipv4 address of the machine
+def get_ip() -> str:
+    command_output = subprocess.check_output('ipconfig', shell=True)
+    ip_adress = re.findall(r"IPv4. . . . . . . . . . . . . . : (\d+\.\d+\.\d+\.\d+)", command_output)[0]
+    return ip_adress
+
 s = socket.socket()
-host = '192.168.1.93'
+host = get_ip()
 port = 5001
 print(f'[+] Conneting to {host}:{port}')
 s.connect((host, port))

--- a/client.py
+++ b/client.py
@@ -9,7 +9,8 @@ BUFFER_SIZE = 4096
 
 # this function will return ipv4 address of the machine
 def get_ip() -> str:
-    command_output = subprocess.check_output('ipconfig', shell=True)
+
+    command_output = subprocess.run(['ipconfig'], check=True, capture_output=True, text=True).stdout.decode()
     ip_adress = re.findall(r"IPv4. . . . . . . . . . . . . . : (\d+\.\d+\.\d+\.\d+)", command_output)[0]
     return ip_adress
 

--- a/client.py
+++ b/client.py
@@ -10,7 +10,7 @@ BUFFER_SIZE = 4096
 # this function will return ipv4 address of the machine
 def get_ip() -> str:
 
-    command_output = subprocess.run(['ipconfig'], check=True, capture_output=True, text=True).stdout.decode()
+    command_output = subprocess.run(['ipconfig'], check=True, capture_output=True, text=True).stdout
     ip_adress = re.findall(r"IPv4. . . . . . . . . . . . . . : (\d+\.\d+\.\d+\.\d+)", command_output)[0]
     return ip_adress
 


### PR DESCRIPTION
Es un simple cambio, pero ahorra un poco de pasos al usuario. Básicamente utiliza subprocess y regex para obtener la ip mediante el output de la función _ipconfig_. 
```python
# this function will return ipv4 address of the machine
def get_ip() -> str:

    command_output = subprocess.run(['ipconfig'], check=True, capture_output=True, text=True).stdout
    ip_adress = re.findall(r"IPv4. . . . . . . . . . . . . . : (\d+\.\d+\.\d+\.\d+)", command_output)[0]
    return ip_adress

s = socket.socket()
host = get_ip()
```